### PR TITLE
Fix min/max setting confusion

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 export function randomInt(min: number, max?: number): number {
   if (max === undefined) {
 		max = min;
-		max = 0;
+		min = 0;
 	}
 
 	return Math.floor(


### PR DESCRIPTION
Looks like there's a typo and max is set twice. Compare lines 3 and 4 to the original: https://github.com/sindresorhus/random-int/blob/master/index.js